### PR TITLE
Update gomobile flags after NDK Unified Headers migration

### DIFF
--- a/cmd/matcha2.go
+++ b/cmd/matcha2.go
@@ -141,11 +141,15 @@ func GetAndroidEnv(gomobpath string) (map[string][]string, error) {
 			a = "armv7a"
 		}
 		target := strings.Join([]string{a, "none", os, env}, "-")
-		sysroot := filepath.Join(ndkRoot, "platforms", toolchain.platform, "arch-"+toolchain.arch)
+		androidApi := strings.TrimPrefix(toolchain.platform, "android-")
+		sysroot := filepath.Join(ndkRoot, "sysroot")
+		isystem := filepath.Join(sysroot, "usr", "include", toolchain.toolPrefix)
+		ldsysroot := filepath.Join(ndkRoot, "platforms", toolchain.platform, "arch-"+toolchain.arch)
 		gcctoolchain := filepath.Join(ndkRoot, "toolchains", toolchain.gcc, "prebuilt", archNDK())
-		flags := fmt.Sprintf("-target %s --sysroot %s -gcc-toolchain %s", target, sysroot, gcctoolchain)
-		cflags := fmt.Sprintf("%s -I%s/include", flags, gomobpath)
-		ldflags := fmt.Sprintf("%s -L%s/usr/lib -L%s/lib/%s", flags, sysroot, gomobpath, arch)
+		flags := fmt.Sprintf("-target %s -gcc-toolchain %s", target, gcctoolchain)
+		cflags := fmt.Sprintf("%s --sysroot %s -isystem %s -D__ANDROID_API__=%s -I%s/include", flags, sysroot, isystem, androidApi, gomobpath)
+		ldflags := fmt.Sprintf("%s --sysroot %s -L%s/lib/%s", flags, ldsysroot, gomobpath, arch)
+
 		androidENV[arch] = []string{
 			"GOOS=android",
 			"GOARCH=" + arch,


### PR DESCRIPTION
This PR fixes issue with `matcha init`:

```
$ matcha init
go install -pkgdir=/Users/divan/pkg/matcha/pkg_android_arm std failed: exit status 2
# runtime/cgo
_cgo_export.c:2:10: fatal error: 'stdlib.h' file not found
```

Quick googling led to this issue in gomobile: https://github.com/golang/go/issues/21802

Bug seems to be due to Unified Headers migration in NDK: https://android.googlesource.com/platform/ndk/+/ndk-release-r16/docs/UnifiedHeadersMigration.md

This PR implements proposed fix in comments to the abovementioned issue. Patch is adapted to matcha codebase, and it solves the problem for me.

Note: I have no idea whether this fix affects something else or not.